### PR TITLE
Fix issue with submodules looking at other submodule class files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>diff-coverage-maven-plugin</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>maven-plugin</packaging>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
     <description>
         Diff coverage maven plugin builds code coverage report of new and modified code based on a provided diff
     </description>

--- a/src/main/kotlin/com/github/surpsg/DiffCoverageMojo.kt
+++ b/src/main/kotlin/com/github/surpsg/DiffCoverageMojo.kt
@@ -52,6 +52,18 @@ class DiffCoverageMojo : AbstractMojo() {
             logPluginProperties(this)
         }
 
+        var found = false
+        for (f in diffCoverageConfig.execFiles) {
+            if (f.isFile) {
+                found = true
+                break
+            }
+        }
+        if (!found) {
+            log.info("No exec files found skipping")
+            return
+        }
+
         ReportGenerator(rootProjectDir, diffCoverageConfig).apply {
             val reportDir = File(diffCoverageConfig.reportsConfig.baseReportDir)
             reportDir.mkdirs()
@@ -150,7 +162,8 @@ class DiffCoverageMojo : AbstractMojo() {
         val includePattern: String = includes.joinToString(",")
         val excludePattern: String = excludes.joinToString(",")
         return if (excludePattern.isEmpty() && includePattern == ALL_FILES_PATTERN) {
-            reactorProjects.map { File(it.build.outputDirectory) }.toSet()
+            reactorProjects.map { File(it.build.outputDirectory) }
+                .filter { outputDirectory -> outputDirectory.path.contains(rootProjectDir.path)}.toSet()
         } else {
             collectFilteredFiles(includePattern, excludePattern)
         }
@@ -159,7 +172,7 @@ class DiffCoverageMojo : AbstractMojo() {
     private fun collectFilteredFiles(includePattern: String, excludePattern: String?): Set<File> {
         return reactorProjects.asSequence()
             .map { project -> File(project.build.outputDirectory) }
-            .filter { outputDirectory -> outputDirectory.exists() }
+            .filter { outputDirectory -> outputDirectory.exists() && outputDirectory.path.contains(rootProjectDir.path)}
             .flatMap { outputDirectory ->
                 FileUtils.getFiles(
                     outputDirectory,

--- a/src/main/kotlin/com/github/surpsg/DiffCoverageMojo.kt
+++ b/src/main/kotlin/com/github/surpsg/DiffCoverageMojo.kt
@@ -20,6 +20,9 @@ class DiffCoverageMojo : AbstractMojo() {
     @Parameter(property = "reactorProjects", required = true, readonly = true)
     private lateinit var reactorProjects: MutableList<MavenProject>
 
+    @Parameter(property = "project", required = true, readonly = true)
+    private lateinit var project: MavenProject
+
     @Parameter(property = "jacoco.dataFile", defaultValue = "\${project.build.directory}/jacoco.exec")
     private lateinit var dataFile: File
 
@@ -45,7 +48,7 @@ class DiffCoverageMojo : AbstractMojo() {
     private var violations = ViolationsConfiguration()
 
     private val rootProjectDir: File
-        get() = reactorProjects[0].basedir
+        get() = project.basedir;
 
     override fun execute() {
         val diffCoverageConfig: DiffCoverageConfig = buildDiffCoverageConfig().apply {


### PR DESCRIPTION
This fixes a problem with submodules where if it was previously built even using mvn clean it will look in other sub modules for their class files.  Class files should be isolated to the module that the diff is being performed on. 
This will also skip running if a jacoco file is not found.