### PR TITLE
Update JaCoCo to version 0.8.10 to be able to use Java 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## [<NEXT-RELEASE>]
 
 ### Fixes
-- no fixes
+- Update JaCoCo to be able to use Java 21
   
 ### Added
 - no new features
 
 ### Dependencies updates
-- no updates
+- JaCoCo 0.8.10
 
 
 ## 0.3.2

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ The plugin does the next steps:
         <plugin> <!-- Make sure JaCoCo plugin is applied -->
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.7</version>
+            <version>0.8.10</version>
         </plugin>
         <plugin>
             <groupId>com.github.surpsg</groupId>
             <artifactId>diff-coverage-maven-plugin</artifactId>
-            <version>0.3.2</version>
+            <version>0.3.3</version>
             <configuration>
                 <!-- Required. diff content source. only one of file, URL or Git is allowed -->
                 <diffSource>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>diff-coverage-maven-plugin</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>maven-plugin</packaging>
-    <version>0.3.2</version>
+    <version>0.3.3-SNAPSHOT</version>
     <description>
         Diff coverage maven plugin builds code coverage report of new and modified code based on a provided diff
     </description>
@@ -112,12 +112,12 @@
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.core</artifactId>
-            <version>0.8.8</version>
+            <version>0.8.10</version>
         </dependency>
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.report</artifactId>
-            <version>0.8.8</version>
+            <version>0.8.10</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
@@ -171,7 +171,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>0.8.10</version>
                 <executions>
                     <execution>
                         <id>pre-unit-test</id>

--- a/src/it/exclude-classes/pom.xml
+++ b/src/it/exclude-classes/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <goals>

--- a/src/it/excluded-all-classes/pom.xml
+++ b/src/it/excluded-all-classes/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <goals>

--- a/src/it/fail-on-duplicated-coverage-config-check/pom.xml
+++ b/src/it/fail-on-duplicated-coverage-config-check/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <goals>

--- a/src/it/git-diff-support/pom.xml
+++ b/src/it/git-diff-support/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <goals>

--- a/src/it/include-classes/pom.xml
+++ b/src/it/include-classes/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <goals>

--- a/src/it/multi-module-reports-exclusions-check/pom.xml
+++ b/src/it/multi-module-reports-exclusions-check/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.10</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/it/multi-module-reports-generation-check/pom.xml
+++ b/src/it/multi-module-reports-generation-check/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.10</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/it/reports-generation-check/pom.xml
+++ b/src/it/reports-generation-check/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <goals>

--- a/src/it/url-source-check/pom.xml
+++ b/src/it/url-source-check/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <goals>

--- a/src/it/violation-rules-check/pom.xml
+++ b/src/it/violation-rules-check/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.10</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Updated JaCoCo to version 0.8.10 to be able to use Java 21.
PR for https://github.com/SurpSG/diff-coverage-maven-plugin/issues/45